### PR TITLE
Update: ommit service-worker

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,9 +24,5 @@
     "32": "/images/icon32.png",
     "48": "/images/icon48.png",
     "128": "/images/icon128.png"
-  },
-  "incognito": "split",
-  "background": {
-    "service_worker": "background.js"
   }
 }


### PR DESCRIPTION
FireFox currently does not support `background.service_worker` and `incognito`  in manifest v3.