### PR TITLE
Fix: Improve Firefox compat in save/setClipboard

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "manifest_version": 3,
   "permissions": [
     "activeTab",


### PR DESCRIPTION
Update the save function to use Blob and URL.createObjectURL for better compatibility with Firefox.
Modify the setClipboard function to use navigator.clipboard.writeText for simplification and cross-browser support.