### PR TITLE
Add clipboard access permission for firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "cookies",
     "downloads",
-    "notifications"
+    "notifications",
+    "clipboardWrite"
   ],
   "host_permissions": ["<all_urls>"],
   "action": {


### PR DESCRIPTION
* Fixed copying cookies to the clipboard
ref : https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#clipboard_access