### PR TITLE
Allow partion key cookies

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,7 @@
  */
 const updateBadgeCounter = async () => {
   const [{ tabId, url } = {}] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const text = url ? (await chrome.cookies.getAll({ url })).length.toFixed() : '';
+  const text = url ? (await chrome.cookies.getAll({ url: url, partitionKey: { topLevelSite: url.origin } })).length.toFixed() : '';
   chrome.action.setBadgeText({ tabId, text });
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,7 @@
  */
 const updateBadgeCounter = async () => {
   const [{ tabId, url } = {}] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const text = url ? (await chrome.cookies.getAll({ url: url, partitionKey: { topLevelSite: url.origin } })).length.toFixed() : '';
+  const text = url ? (await chrome.cookies.getAll({ url: url, partitionKey: { topLevelSite: url.host }})).length.toFixed() : '';
   chrome.action.setBadgeText({ tabId, text });
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,7 @@
  */
 const updateBadgeCounter = async () => {
   const [{ tabId, url } = {}] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const text = url ? (await chrome.cookies.getAll({ url: url, partitionKey: { topLevelSite: url.host }})).length.toFixed() : '';
+  const text = url ? (await chrome.cookies.getAll({ url: url, partitionKey: { topLevelSite: url.origin }})).length.toFixed() : '';
   chrome.action.setBadgeText({ tabId, text });
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "manifest_version": 3,
   "permissions": [
     "activeTab",

--- a/src/popup.js
+++ b/src/popup.js
@@ -87,7 +87,7 @@ getUrlPromise.then(url => {
 });
 
 /** Set Cookies data to the table */
-getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelSite: url.host }})).then(cookies => {
+getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelSite: url.origin }})).then(cookies => {
   const netscape = jsonToNetscapeMapper(cookies);
   const tableRows = netscape.map(row => {
     const tr = document.createElement('tr');
@@ -104,21 +104,21 @@ getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelS
 document.querySelector('#export').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.host }});
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
   save(text, url.hostname + '_cookies', format);
 });
 
 document.querySelector('#exportAs').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.host }});
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
   save(text, url.hostname + '_cookies', format, true);
 });
 
 document.querySelector('#copy').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.host }});
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
   setClipboard(text);
 });
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -87,7 +87,7 @@ getUrlPromise.then(url => {
 });
 
 /** Set Cookies data to the table */
-getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelSite: url.origin }})).then(cookies => {
+getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelSite: url.host }})).then(cookies => {
   const netscape = jsonToNetscapeMapper(cookies);
   const tableRows = netscape.map(row => {
     const tr = document.createElement('tr');
@@ -104,21 +104,21 @@ getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelS
 document.querySelector('#export').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.host }});
   save(text, url.hostname + '_cookies', format);
 });
 
 document.querySelector('#exportAs').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.host }});
   save(text, url.hostname + '_cookies', format, true);
 });
 
 document.querySelector('#copy').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.host }});
   setClipboard(text);
 });
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -7,7 +7,7 @@ const getUrlPromise = chrome.tabs.query({ active: true, currentWindow: true })
 
 /**
  * Convert Chrome's JSON format cookies data to a string array for Netscape format
- * @param {CookieJson[]} jsonData 
+ * @param {CookieJson[]} jsonData
  * @returns {string[][7]}
  */
 const jsonToNetscapeMapper = (jsonData) => {
@@ -87,7 +87,7 @@ getUrlPromise.then(url => {
 });
 
 /** Set Cookies data to the table */
-getUrlPromise.then(url => chrome.cookies.getAll({ url })).then(cookies => {
+getUrlPromise.then(url => chrome.cookies.getAll({ url, partitionKey: { topLevelSite: url.origin }})).then(cookies => {
   const netscape = jsonToNetscapeMapper(cookies);
   const tableRows = netscape.map(row => {
     const tr = document.createElement('tr');
@@ -104,20 +104,21 @@ getUrlPromise.then(url => chrome.cookies.getAll({ url })).then(cookies => {
 document.querySelector('#export').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href });
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
   save(text, url.hostname + '_cookies', format);
 });
 
 document.querySelector('#exportAs').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
   const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, { url: url.href });
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
   save(text, url.hostname + '_cookies', format, true);
 });
 
 document.querySelector('#copy').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
-  const text = await getCookieText(format, { url: await getUrlPromise });
+  const url = new URL(await getUrlPromise);
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin }});
   setClipboard(text);
 });
 


### PR DESCRIPTION
From this conversation it seems that we need to add a partitionkey field to the cookies.GetAll method:
https://groups.google.com/a/chromium.org/g/chromium-extensions/c/Nh90FWSCong/m/MXzxU30fAAAJ

Using the details for how a partitionkey should look
https://developer.chrome.com/docs/extensions/reference/api/cookies#type-CookiePartitionKey

And the general GetAll() api
https://developer.chrome.com/docs/extensions/reference/api/cookies#method-getAll

I have updated the code that needs to be updated. I think export all might not work with partitioned keys. I think you can only get partioned keys for one site at a time so I am not sure if extending this functionality will extend there.

Closes #57 