### PR TITLE
Get both partitioned and non-partitioned cookies

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -14,8 +14,18 @@ const getAllCookies = async (details) => {
  * Update icon badge counter on active page
  */
 const updateBadgeCounter = async () => {
-  const [{ tabId, url } = {}] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const text = url ? (await getAllCookies({ url: url, partitionKey: { topLevelSite: url.origin }})).length.toFixed() : '';
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab) {
+    return;
+  }
+  const { id: tabId, url: urlString } = tab;
+  if (!urlString) {
+    chrome.action.setBadgeText({ tabId, text: '' });
+    return;
+  }
+  const url = new URL(urlString);
+  const cookies = await getAllCookies({ url: url.href, partitionKey: { topLevelSite: url.origin } });
+  const text = cookies.length.toFixed();
   chrome.action.setBadgeText({ tabId, text });
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,21 @@
 /**
+ * Retrieves both cookies with and without a partition key and returns the merged list
+ * @param {chrome.cookies.GetAllDetails} details
+ * @returns {chrome.cookies.Cookie[]}
+ */
+const getAllCookies = async (details) => {
+  const { partitionKey, ...detailsWithoutPartitionKey } = details;
+  const cookiesWithPartitionKey = await chrome.cookies.getAll(details);
+  const cookies = await chrome.cookies.getAll(detailsWithoutPartitionKey);
+  return [...cookies, ...cookiesWithPartitionKey]
+}
+
+/**
  * Update icon badge counter on active page
  */
 const updateBadgeCounter = async () => {
   const [{ tabId, url } = {}] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const text = url ? (await chrome.cookies.getAll({ url: url, partitionKey: { topLevelSite: url.origin }})).length.toFixed() : '';
+  const text = url ? (await getAllCookies({ url: url, partitionKey: { topLevelSite: url.origin }})).length.toFixed() : '';
   chrome.action.setBadgeText({ tabId, text });
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "manifest_version": 3,
   "permissions": [
     "activeTab",

--- a/src/popup.js
+++ b/src/popup.js
@@ -102,18 +102,18 @@ getUrlPromise.then(url => {
 getUrlPromise
   .then(url => getAllCookies({ url: url.href, partitionKey: { topLevelSite: url.origin } }))
   .then(cookies => {
-  const netscape = jsonToNetscapeMapper(cookies);
-  const tableRows = netscape.map(row => {
-    const tr = document.createElement('tr');
-    tr.replaceChildren(...row.map(v => {
-      const td = document.createElement('td');
-      td.textContent = v;
-      return td;
-    }));
-    return tr;
+    const netscape = jsonToNetscapeMapper(cookies);
+    const tableRows = netscape.map(row => {
+      const tr = document.createElement('tr');
+      tr.replaceChildren(...row.map(v => {
+        const td = document.createElement('td');
+        td.textContent = v;
+        return td;
+      }));
+      return tr;
+    });
+    document.querySelector('table tbody').replaceChildren(...tableRows);
   });
-  document.querySelector('table tbody').replaceChildren(...tableRows);
-});
 
 document.querySelector('#export').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
@@ -138,7 +138,7 @@ document.querySelector('#copy').addEventListener('click', async () => {
 
 document.querySelector('#exportAll').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
-  const text = await getCookieText(format, {});
+  const text = await getCookieText(format, { partitionKey: {} });
   save(text, 'cookies', format);
 });
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -2,7 +2,7 @@
 
 /** Promise to get URL of Active Tab */
 const getUrlPromise = chrome.tabs.query({ active: true, currentWindow: true })
-  .then(([{ url }]) => url);
+  .then(([{ url }]) => new URL(url));
 
 
 /**
@@ -95,11 +95,13 @@ const getAllCookies = async (details) => {
 /** Set URL in the header */
 getUrlPromise.then(url => {
   const location = document.querySelector('#location');
-  location.textContent = location.href = new URL(url).href;
+  location.textContent = location.href = url.href;
 });
 
 /** Set Cookies data to the table */
-getUrlPromise.then(url => getAllCookies({ url, partitionKey: { topLevelSite: url.origin }})).then(cookies => {
+getUrlPromise
+  .then(url => getAllCookies({ url: url.href, partitionKey: { topLevelSite: url.origin } }))
+  .then(cookies => {
   const netscape = jsonToNetscapeMapper(cookies);
   const tableRows = netscape.map(row => {
     const tr = document.createElement('tr');
@@ -115,22 +117,22 @@ getUrlPromise.then(url => getAllCookies({ url, partitionKey: { topLevelSite: url
 
 document.querySelector('#export').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
-  const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, {url: url.href, partitionKey: {topLevelSite: url.origin}});
+  const url = await getUrlPromise;
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin } });
   save(text, url.hostname + '_cookies', format);
 });
 
 document.querySelector('#exportAs').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
-  const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, {url: url.href, partitionKey: {topLevelSite: url.origin}});
+  const url = await getUrlPromise;
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin } });
   save(text, url.hostname + '_cookies', format, true);
 });
 
 document.querySelector('#copy').addEventListener('click', async () => {
   const format = FormatMap[document.querySelector('#format').value];
-  const url = new URL(await getUrlPromise);
-  const text = await getCookieText(format, {url: url.href, partitionKey: {topLevelSite: url.origin}});
+  const url = await getUrlPromise;
+  const text = await getCookieText(format, { url: url.href, partitionKey: { topLevelSite: url.origin } });
   setClipboard(text);
 });
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -75,7 +75,7 @@ const setClipboard = async (text) => {
  * @returns {string}
  */
 const getCookieText = async (format, details) => {
-  const cookies = await getAllCookies(details)
+  const cookies = await getAllCookies(details);
   return format.serializer(cookies);
 }
 


### PR DESCRIPTION
During testing of the previous fix, I found that sometimes with the new partition key header, some cookies without a partition key was now no longer being retrieved.

My proposed solution is to get the cookies with partition key and cookies without a partition key and merge the results. The new array will contain all cookies with and without partition keys.

In the event of there being cookies with the same name in both sets, the set within the partitioned key section will take precedence.