### PR TITLE
Feature/support firefox again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,5 @@ dist
 # TernJS port file
 .tern-port
 
+dst/
 *.zip

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Specifically, it now needs "Download management" to execute a more appropriate f
 1. Download and unzip this repository.
 2. Merge `src/manifest.json` and `src/manifest-firefox.json` using one of the following methods:
    - `npm install && npm run build:firfox` and install generated `.zip` file.
-   - `jq -s '.[0] + .[1]' src/manifest.json src/manifest.firefox.json > src/manifest.json` and install the extension from the `src` rectory.
+   - `jq -s '.[0] + .[1]' src/manifest.json src/manifest-firefox.json > src/manifest.json` and install the extension from the `src` rectory.
    - Merge manually.
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Specifically, it now needs "Download management" to execute a more appropriate f
 3. Enable "Developer mode".
 4. Click on "Load Unpacked" and open the directory `Get-cookies.txt-LOCALLY/src`.
 
+## Build for Firefox
+1. Download and unzip this repository.
+2. Merge `src/manifest.json` and `src/manifest-firefox.json` using one of the following methods:
+   - `npm install && npm run build:firfox` and install generated `.zip` file.
+   - `jq -s '.[0] + .[1]' src/manifest.json src/manifest.firefox.json > src/manifest.json` and install the extension from the `src` rectory.
+   - Merge manually.
+
 
 
 ## Example of extension installation directory (Google Chrome)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Specifically, it now needs "Download management" to execute a more appropriate f
 ## Build for Firefox
 1. Download and unzip this repository.
 2. Merge `src/manifest.json` and `src/manifest-firefox.json` using one of the following methods:
-   - `npm install && npm run build:firfox` and install generated `.zip` file.
+   - `npm install && npm run build:firfox` and install generated `.zip` file from the `dist` directory.
    - `jq -s '.[0] + .[1]' src/manifest.json src/manifest-firefox.json > src/manifest.json` and install the extension from the `src` rectory.
    - Merge manually.
 

--- a/build.js
+++ b/build.js
@@ -17,8 +17,9 @@ const getGitInfo = () => {
 
 const build = async ({ branch, commitHash }) => {
   const mode = options.firefox ? 'firefox' : 'chrome';
-  const zipPath = `${branch.replace('/', '_')}_${commitHash.slice(0,5)}_${mode}.zip`;
-  const output = fs.createWriteStream(path.join(__dirname, zipPath));
+  const zipName = `${branch.replace('/', '_')}_${commitHash.slice(0,5)}_${mode}.zip`;
+  fs.mkdirSync(path.join(__dirname, 'dst'), { recursive: true });
+  const output = fs.createWriteStream(path.join(__dirname, 'dst', zipName));
 
   process.chdir(path.join(__dirname, 'src'));
 
@@ -36,8 +37,8 @@ const build = async ({ branch, commitHash }) => {
   }
   archive.append(JSON.stringify(manifest, null, 2), { name: 'manifest.json' });
 
-  await archive.finalize();
-  console.log('BUILD', zipPath);
+  archive.finalize();
+  console.log('BUILD', zipName);
 };
 
 build(getGitInfo());

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "Get-cookies.txt-LOCALLY",
       "devDependencies": {
         "@types/chrome": "^0.0.218",
         "@types/wicg-file-system-access": "^2020.9.5",
         "archiver": "^5.3.1",
+        "commander": "^12.1.0",
         "icon-gen": "^3.0.1",
         "prettier": "^3.2.5"
       }
@@ -331,12 +331,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "engines": {
-        "node": ">= 12"
+        "node": ">=18"
       }
     },
     "node_modules/compress-commons": {
@@ -605,6 +605,15 @@
       "bin": {
         "icon-gen": "dist/bin/index.js"
       },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/icon-gen/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
     "@types/chrome": "^0.0.218",
     "@types/wicg-file-system-access": "^2020.9.5",
     "archiver": "^5.3.1",
+    "commander": "^12.1.0",
     "icon-gen": "^3.0.1",
     "prettier": "^3.2.5"
   },
   "scripts": {
     "format": "npx prettier --write src",
-    "build": "npm run format && node build.js"
+    "build": "npm run build:chrome && npm run build:firefox",
+    "build:chrome": "node build.js",
+    "build:firefox": "node build.js --firefox"
   }
 }

--- a/src/background.html
+++ b/src/background.html
@@ -1,0 +1,2 @@
+<!-- This file is used to load the background script on Firefox. -->
+<script type="module" src="background.mjs"></script>

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,0 +1,11 @@
+{
+  "incognito": "spanning",
+  "background": {
+    "page": "background.html"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{ac87cfd8-47b1-4401-b32e-f033af5ed96b}"
+    }
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "manifest_version": 3,
   "permissions": ["activeTab", "cookies", "downloads", "notifications"],
   "host_permissions": ["<all_urls>"],

--- a/src/modules/get_all_cookies.mjs
+++ b/src/modules/get_all_cookies.mjs
@@ -1,6 +1,29 @@
+/**
+ * Get all cookies that match the given criteria.
+ * @param {chrome.cookies.GetAllDetails} details
+ * @returns {Promise<chrome.cookies.Cookie[]>}
+ */
 export default async function getAllCookies(details) {
+  details.storeId ??= await getCurrentCookieStoreId();
   const { partitionKey, ...detailsWithoutPartitionKey } = details;
   const cookiesWithPartitionKey = partitionKey ? await chrome.cookies.getAll(details) : [];
   const cookies = await chrome.cookies.getAll(detailsWithoutPartitionKey);
   return [...cookies, ...cookiesWithPartitionKey];
 }
+
+/**
+ * Get the current cookie store ID.
+ * @returns {Promise<string | undefined>}
+ */
+const getCurrentCookieStoreId = async () => {
+  // If the extension is in split incognito mode, return undefined to choose the default store.
+  if (chrome.runtime.getManifest().incognito === 'split') return undefined;
+
+  // Firefox supports the `tab.cookieStoreId` property.
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (tab.cookieStoreId) return tab.cookieStoreId;
+
+  // Chrome does not support the `tab.cookieStoreId` property.
+  const stores = await chrome.cookies.getAllCookieStores();
+  return stores.find((store) => store.tabIds.includes(tab.id))?.id;
+};


### PR DESCRIPTION
- use `background.html` for firefox v2 api.
- use `getCurrentCookieStoreId()` for firefox, because it doesn't support `"incognito": "split"`.
- add `manifest-firefox.json` to modify `manifest.json` for firefox.
- update build scripts.