### PR TITLE
Fix/wait download done for firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "manifest_version": 3,
   "permissions": ["activeTab", "cookies", "downloads", "notifications"],
   "host_permissions": ["<all_urls>"],


### PR DESCRIPTION
Fix: Firefox fails to download if revoke URL is done before completion