### PR TITLE
Hotfix/support browsers unware of partition key

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "manifest_version": 3,
   "permissions": ["activeTab", "cookies", "downloads", "notifications"],
   "host_permissions": ["<all_urls>"],

--- a/src/modules/get_all_cookies.mjs
+++ b/src/modules/get_all_cookies.mjs
@@ -6,7 +6,10 @@
 export default async function getAllCookies(details) {
   details.storeId ??= await getCurrentCookieStoreId();
   const { partitionKey, ...detailsWithoutPartitionKey } = details;
-  const cookiesWithPartitionKey = partitionKey ? await chrome.cookies.getAll(details) : [];
+  // Error handling for browsers that do not support partitionKey, such as chrome < 119.
+  // `chrome.cookies.getAll()` returns Promise but cannot directly catch() chain.
+  const cookiesWithPartitionKey = partitionKey ?
+    await Promise.resolve().then(() => chrome.cookies.getAll(details)).catch(() => []) : [];
   const cookies = await chrome.cookies.getAll(detailsWithoutPartitionKey);
   return [...cookies, ...cookiesWithPartitionKey];
 }


### PR DESCRIPTION
Adding error handling will prevent crashes on browsers that do not support partition keys, such as chrome < 119.
However, they may not be able to read cookies with partition keys set.
Close #71 