### PR TITLE
Add 'Click to Copy' option

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Get cookies.txt LOCALLY",
   "description": "Get cookies.txt, NEVER send information outside with open-source",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "manifest_version": 3,
-  "permissions": ["activeTab", "cookies", "downloads", "notifications"],
+  "permissions": ["activeTab", "cookies", "downloads", "notifications", "storage"],
   "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "popup.html",

--- a/src/modules/table-click-to-copy.mjs
+++ b/src/modules/table-click-to-copy.mjs
@@ -1,0 +1,53 @@
+/** Link tag referring to 'modules/table-click-to-copy.mjs' */
+export const styleSheet = document.getElementById('clickToCopyStyleSheet');
+styleSheet.disabled = true;
+
+/** ID of the 'Click to Copy' checkbox */
+export const checkboxId = 'clickToCopyOption';
+
+const selector = '#netscapeTable > tbody > tr > td';
+
+/**
+ * Copy text data to the clipboard
+ * @param {string} text
+ */
+export const setClipboard = async (text) => {
+    await navigator.clipboard.writeText(text);
+    document.getElementById('copy').innerText = 'Copied!';
+}
+
+/**
+ * Callback function for td elements' 'click' event listeners
+ * @param {object} event
+ */
+const tableCellEventListenerCallback = (event) => {
+    setClipboard(event.target.innerText);
+}
+
+/**
+ * Assign a 'click' event listener to each cell in the netscape table
+ */
+export const addTableCellsEventListeners = () => {
+    for (let td of document.querySelectorAll(selector)) {
+        td.addEventListener('click', tableCellEventListenerCallback);
+    }
+}
+
+/**
+ * Make 'Click to Copy' checkbox set its renewed state in browser storage;
+ * Toggle stylesheet and event listeners for netscape table cells
+ */
+document.getElementById(checkboxId).addEventListener('change', (event) => {
+    const checkboxChecked = event.target.checked;
+    chrome.storage.sync.set({[checkboxId]: checkboxChecked}, () => {
+        styleSheet.disabled = !checkboxChecked;
+        if (checkboxChecked) {
+            addTableCellsEventListeners();
+        }
+        else {
+            for (let td of document.querySelectorAll(selector)) {
+                td.removeEventListener('click', tableCellEventListenerCallback);
+            }
+        }
+    });
+})

--- a/src/popup-options-click-to-copy.css
+++ b/src/popup-options-click-to-copy.css
@@ -1,0 +1,5 @@
+#netscapeTable > tbody > tr > td:hover {
+    opacity: 50%;
+    cursor: pointer;
+    user-select: none;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="popup-options.css" />
     <link rel="stylesheet" href="iconfont/material-icons.css" />
     <link rel="stylesheet" href="donation.css" />
+    <link rel="stylesheet" id="clickToCopyStyleSheet" href="popup-options-click-to-copy.css" />
     <script src="popup.mjs" type="module" defer></script>
     <script src="table-nowrap.js" defer></script>
   </head>
@@ -49,6 +50,11 @@
         <div class="nowrap-option option">
           <label for="nowrapOption">Table Nowrap: </label>
           <input type="checkbox" id="nowrapOption" name="nowrapOption" checked />
+        </div>
+
+        <div class="click-to-copy-option option">
+          <label for="clickToCopyOption">Click to Copy:</label>
+          <input type="checkbox" id="clickToCopyOption" name="clickToCopyOption" disabled />
         </div>
       </div>
 


### PR DESCRIPTION
I have an interest in web scrapers—I use them often to scrape media off the web for my own purposes. However, whenever **Cloudflare** updates their anti-bot measures, programming libraries that specialise in bypassing Cloudflare become useless/broken unless likewise updated. So whenever you want to scrape data from a website that uses Cloudflare, you have to:

1. Manually go to the website and prove that you are not a bot (e.g., by completing a CAPTCHA)
2. Wait for the page to reload and retrieve the value of the `cf_clearance` cookie (via Developer Tools, **this extension**, etc.)
3. Pass the `cf_clearance` cookie to the web scraper

I was going to create my own little browser extension that would copy the value of the `cf_clearance` cookie, if found, to the user's clipboard, but I figured that that would just be bloating the **Chrome Web Store**.

This extension, **Get cookies.txt LOCALLY**, is a very good one. You can quite easily text-select the cookie you want in the netscape table and copy as is, but I figured that adding a "Click to Copy" option would make doing so faster and more convenient. So here is my pull request.

No hard feelings if this gets rejected. Yet, as a humble request, I would like for a feature similar to the one I am proposing to be considered in a future update.

Best,

gitchasing