### PR TITLE
Update cookie_format.mjs

### DIFF
--- a/src/modules/cookie_format.mjs
+++ b/src/modules/cookie_format.mjs
@@ -25,8 +25,8 @@ export const formatMap = {
       const netscapeTable = jsonToNetscapeMapper(cookies);
       const text = [
         '# Netscape HTTP Cookie File',
-        '# http://curl.haxx.se/rfc/cookie_spec.html',
-        '# This is a generated file!  Do not edit.',
+        '# https://curl.haxx.se/rfc/cookie_spec.html',
+        '# This is a generated file! Do not edit.',
         '',
         ...netscapeTable.map((row) => row.join('\t')),
         '', // Add a new line at the end


### PR DESCRIPTION
`Changed "http" to "https" and removed a double whitespace.`



I noticed that other cookie extract extensions used "https" instead of "http" for the "curl.haxx.se" website link, so I thought I should change it here as well. If this extension for some reason have to be using "http" instead of "https", please ignore this pull request. I have also removed a double whitespace that came right after "This is a generated file!".