### PR TITLE
Fix firefox font-size to 75%, the same as chrome

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -8,6 +8,7 @@ html {
 body {
   margin: 8px;
   width: 484px;
+  font-size: 75%;
 }
 
 h1 {


### PR DESCRIPTION
Fix firefox font-size to 75%, the same as chrome